### PR TITLE
Fixes .dll search on windows.

### DIFF
--- a/library.lisp
+++ b/library.lisp
@@ -1,7 +1,9 @@
 (in-package #:cl-liballegro)
 
 (define-foreign-library liballegro
-  (:windows "allegro-5.0.8-monolith-mt.dll")
+  (:windows (:or
+	     "allegro-5.0.8-monolith-mt.dll"
+	     "./allegro-5.0.8-monolith-mt.dll"))	    
   (:unix (:default "liballegro")))
 (use-foreign-library liballegro)
 


### PR DESCRIPTION
I was getting a 126 error when trying to load the allegro dll on windows, but this fixed it.
