### PR TITLE
Fixed export of unlock-bitmap

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -294,7 +294,7 @@
    #:get-pixel-format-bits
    #:lock-bitmap
    #:lock-bitmap-region
-   #:unlock-butmap
+   #:unlock-bitmap
 
    ;; Bitmap Creation
    #:create-bitmap


### PR DESCRIPTION
Hello!
I've stumbled upon a typo that prevents from using al_unlock_bitmap. This PR fixes it.