### PR TITLE
Fixed al_draw_bitmap_region and al_draw_tinted_bitmap_region parameter list

### DIFF
--- a/src/ffi-functions/graphics.lisp
+++ b/src/ffi-functions/graphics.lisp
@@ -85,12 +85,12 @@
   (flags draw-flags))
 (defcfun ("al_draw_bitmap_region" draw-bitmap-region) :void
   (bitmap :pointer)
-  (sx c-float) (sy c-float) (sw c-float) (sh c-float) (dx c-float (dy c-float))
+  (sx c-float) (sy c-float) (sw c-float) (sh c-float) (dx c-float) (dy c-float)
   (flags draw-flags))
 (defcfun ("al_draw_tinted_bitmap_region" draw-tinted-bitmap-region) :void
   (bitmap :pointer)
   (color (:struct color))
-  (sx c-float) (sy c-float) (sw c-float) (sh c-float) (dx c-float (dy c-float))
+  (sx c-float) (sy c-float) (sw c-float) (sh c-float) (dx c-float) (dy c-float)
   (flags draw-flags))
 (defcfun ("al_draw_pixel" draw-pixel) :void
   (x c-float) (y c-float)


### PR DESCRIPTION
Hello!
I was trying to use `al_draw_bitmap_region`, but found out that it expects different number of parameters than specified in [documentation](https://www.allegro.cc/manual/5/al_draw_bitmap_region). I think there's typo in cl-liballegro with extra paren; with this fix I was able to use the function properly.