### PR TITLE
Added al_ferrmsg function

### DIFF
--- a/src/ffi-functions/file-io.lisp
+++ b/src/ffi-functions/file-io.lisp
@@ -11,6 +11,7 @@
 (defcfun ("al_fseek" fseek) :boolean (file :pointer) (offset :uint64) (whence seek))
 (defcfun ("al_feof" feof) :boolean (file :pointer))
 (defcfun ("al_ferror" ferror) :boolean (file :pointer))
+(defcfun ("al_ferrmsg" ferrmsg) :string (file :pointer))
 (defcfun ("al_fclearerr" fclearerr) :void (file :pointer))
 (defcfun ("al_fungetc" fungetc) :int (file :pointer) (c :int))
 (defcfun ("al_fsize" fsize) :uint64 (file :pointer)) 

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -218,6 +218,7 @@
    #:fseek
    #:feof
    #:ferror
+   #:ferrmsg
    #:fclearerr
    #:fungetc
    #:fsize


### PR DESCRIPTION
Hello!
This tiny PR adds [al_ferrmsg](https://liballeg.org/a5docs/trunk/file.html#al_ferrmsg) function to exports. It comes in handy when using Allegro's file APIs.