### PR TITLE
Add MacOS compatibility

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,7 +29,8 @@ libffi
  #+END_SRC
 6. I've got a neat OPTIONAl lispy interface [[https://github.com/resttime/cl-liballegro/tree/master/src/interface/interface.lisp][here]]
 7. Everything else is pretty much 1-to-1
-8. Examples exist if you get lost
+8. If you're getting crashes on MacOS, put all your code into [[https://common-lisp.net/project/cffi/manual/html_node/defcallback.html][callback]] and pass it to [[https://www.allegro.cc/manual/5/al_run_main][al:run-main]].
+9. Examples exist if you get lost
 
 *Feel free to raise an issue to request a feature or for me to work on something*
 

--- a/cl-liballegro.asd
+++ b/cl-liballegro.asd
@@ -82,6 +82,7 @@
        (:file "timer")
        (:file "touch-input")
        (:file "transformations")
+       (:file "misc")
        (:file "platform-specific")
        (:file "direct3d")
        (:file "opengl")

--- a/src/ffi-functions/misc.lisp
+++ b/src/ffi-functions/misc.lisp
@@ -1,0 +1,5 @@
+(in-package #:cl-liballegro)
+
+;; Miscellaneous routines
+(defcfun ("al_run_main" run-main) :int
+  (argc :int) (argv :pointer) (user-main :pointer))

--- a/src/library.lisp
+++ b/src/library.lisp
@@ -4,6 +4,9 @@
   "Use macro for easier versioning.  Debug using MACROEXPAND-1"
   `(define-foreign-library ,(intern (string-upcase lib))
      (:windows ,(concatenate 'string (subseq lib 3) "-5.2.dll"))
+     (:darwin (:or ,(concatenate 'string lib ".5.2.6.dylib")
+                   ,(concatenate 'string lib ".5.2.dylib")
+                   ,(concatenate 'string lib ".dylib")))
      (:unix (:or ,(concatenate 'string lib ".so.5.2.6")
                  ,(concatenate 'string lib ".so.5.2")
                  ,(concatenate 'string lib ".so")))
@@ -19,9 +22,6 @@
 
 (define-allegro-library "liballegro")
 (use-foreign-library liballegro)
-
-(define-allegro-library "liballegro_main")
-(use-foreign-library liballegro_main)
 
 (define-allegro-library "liballegro_acodec")
 (use-foreign-library liballegro_acodec)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -719,6 +719,7 @@
 
 ;;; Miscellaneous routines
    #:+pi+
+   #:run-main
 
 ;;; OpenGL
    #:get-opengl-extension-list


### PR DESCRIPTION
Hello!
This PR adds missing MacOS compatibility.
1. First of all, the libraries on mac have .dylib suffix, I've tweaked `define-allegro-library` macro accordingly.
2. Second, there's some limitation on mac programs intializing OpenGL windows - they should initialize it in non-primary thread. Because of that, there's function [`al_run_main`](https://www.allegro.cc/manual/5/al_run_main), which does nothing on Windows and Linux and spawns threads in right order on MacOS, so I've added the binding for that function. This stuff is known to be a headache for binding library writers (see e.g. https://github.com/dradtke/go-allegro/issues/3).
3. Finally, `allegro_main` library turns out to be a stub for C programs to use the right `main` function, so it does not make much sense for anything outside of C world. Moreover, trying to use it with `define-foreign-library` causes errors on Mac because it requires `__al_mangled_main` symbol to be present in binary which calls `dlopen` on it, and we cannot do that easily using CFFI. The programs using cl-liballegro seem to work fine even without allegro_main, so I allowed myself to remove it completely.

I've tested the changes on High Sierra vm and it looks like it's working.