### PR TITLE
set-audio-stream-playing

### DIFF
--- a/src/ffi-functions/addons/audio.lisp
+++ b/src/ffi-functions/addons/audio.lisp
@@ -184,7 +184,7 @@
 (defcfun ("al_get_audio_stream_playing" get-audio-stream-playing) :boolean
   (stream :pointer))
 (defcfun ("al_set_audio_stream_playing" set-audio-stream-playing) :boolean
-  (stream :pointer) (val c-float))
+  (stream :pointer) (val :boolean))
 (defcfun ("al_get_audio_stream_playmode" get-audio-stream-playmode) playmode
   (stream :pointer))
 (defcfun ("al_set_audio_stream_playmode" set-audio-stream-playmode) :boolean


### PR DESCRIPTION
set-audio-stream-playing was requiring a float as its second parameter instead of a boolean, meaning that you could only always set a stream to be playing

(please disregard if there is an actual reason for set-audio-stream-playing to take a float instead of a boolean and I just didn't figure it out cuz I'm dumb)