### PR TITLE
Fix return value of init-font-addon

### DIFF
--- a/src/ffi-functions/addons/font.lisp
+++ b/src/ffi-functions/addons/font.lisp
@@ -2,7 +2,7 @@
 
 ;;; Font addons
 ;; General font routinues
-(defcfun ("al_init_font_addon" init-font-addon) :void)
+(defcfun ("al_init_font_addon" init-font-addon) :boolean)
 (defcfun ("al_shutdown_font_addon" shutdown-font-addon) :void)
 (defcfun ("al_load_font" load-font) :pointer
   (filename :string) (size :int) (flags :int))


### PR DESCRIPTION
Hey!
This small PR fixes the return value of [`al_init_font_addon`](https://liballeg.org/a5docs/trunk/font.html#al_init_font_addon) wrapper - I belive it was `bool` the whole time :smiley: 