### PR TITLE
Remove export for undefined function get-display-flag

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -148,7 +148,6 @@
 
    ;; Display Settings
    #:get-display-flags
-   #:get-display-flag
    #:toggle-display-flag
    #:get-display-option
    #:get-display-format


### PR DESCRIPTION
Allegro 5 does not define a function with this name.