### PR TITLE
Add |none| to keyboard enum

### DIFF
--- a/src/constants/keyboard.lisp
+++ b/src/constants/keyboard.lisp
@@ -2,6 +2,7 @@
 
 ;; Keycodes
 (defcenum keycodes
+    (:|none| 0)
   (:a 1)
   (:b 2)
   (:c 3)
@@ -138,7 +139,7 @@
 
 ;; Keyboard modifier flags
 (defbitfield keymods
-  (:shift #x00001)
+    (:shift #x00001)
   (:ctrl #x00002)
   (:alt #x00004)
   (:lwin #x00008)


### PR DESCRIPTION
Fixes #47.
Add |none| for keycodes 0, corresponding to "(none)" in the C library version.