### PR TITLE
Add generic method to initialize joysticks

### DIFF
--- a/src/interface/interface.lisp
+++ b/src/interface/interface.lisp
@@ -45,6 +45,10 @@
   (:method (system)
     (al:install-keyboard)
     (al:register-event-source (event-queue system) (al:get-keyboard-event-source))))
+(defgeneric initialize-joystick (system)
+  (:method (system)
+    (al:install-joystick)
+    (al:register-event-source (event-queue system) (al:get-joystick-event-source))))
 
 ;;; Generic Handlers
 (defgeneric joystick-axis-handler (system) (:method (system)))
@@ -145,7 +149,8 @@
     (initialize-event-queue system)
     (initialize-display system)
     (initialize-mouse system)
-    (initialize-keyboard system)))
+    (initialize-keyboard system)
+    (initialize-joystick system)))
 
 (defgeneric shutdown-system (system)
   (:method (system)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1240,4 +1240,4 @@
    #:get-video-frame
    #:get-video-position
    #:seek-video
-   ))
+   #:initialize-joystick))


### PR DESCRIPTION
We listened to joystick events and provided handlers without setting up the joystick functionality.