### PR TITLE
Added stream-file-position accesors for binary-stream

### DIFF
--- a/src/interface/streams.lisp
+++ b/src/interface/streams.lisp
@@ -144,6 +144,15 @@ interactive restart allowing to specify another filename."
       (let ((pointer (cffi:inc-pointer buffer start)))
         (+ start (fread file pointer (- end start)))))))
 
+(defmethod trivial-gray-streams:stream-file-position ((stream binary-stream))
+  (with-slots (file) stream
+    (ftell file)))
+
+(defmethod (setf trivial-gray-streams:stream-file-position)
+    (newval (stream binary-stream))
+  (with-slots (file) stream
+    (fseek file newval 0)))
+
 (defmethod trivial-gray-streams::close ((stream binary-stream) &key abort)
   (declare (ignore abort))
   (with-slots (file) stream


### PR DESCRIPTION
Hey! When implementing Gray stream wrappers for liballegro file I/O APIs in #36, I managed to forget the `stream-file-position` method for binary stream 😅 This PR fixes it.