### PR TITLE
Fixes for color addon functions

### DIFF
--- a/src/ffi-functions/addons/color.lisp
+++ b/src/ffi-functions/addons/color.lisp
@@ -11,7 +11,7 @@
 (defcfun ("al_color_hsl_to_rgb" color-hsl-to-rgb) :void
   (hue c-float) (saturation c-float) (lightness c-float)
   (red :pointer) (green :pointer) (blue :pointer))
-(defcfun ("al_color_hsl" color-hsv) (:struct color)
+(defcfun ("al_color_hsv" color-hsv) (:struct color)
   (h c-float) (s c-float) (r c-float))
 (defcfun ("al_color_hsv_to_rgb" color-hsv-to-rgb) :void
   (hue c-float) (saturation c-float) (value c-float)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1060,38 +1060,25 @@
    #:get-allegro-acodec-version
 
 ;;; Color addon
-   #:color_cmyk
-   #:color_cmyk_to_rgb
-   #:color_hsl
-   #:color_hsl_to_rgb
-   #:color_hsv
-   #:color_hsv_to_rgb
-   #:color_html
-   #:color_html_to_rgb
-   #:color_rgb_to_html
-   #:color_name
-   #:color_name_to_rgb
-   #:color_rgb_to_cmyk
-   #:color_rgb_to_hsl
-   #:color_rgb_to_hsv
-   #:color_rgb_to_name
-   #:color_rgb_to_xyz
-   #:color_xyz
-   #:color_xyz_to_rgb
-   #:color_rgb_to_xyy
-   #:color_xyy
-   #:color_xyy_to_rgb
-   #:color_rgb_to_lab
-   #:color_lab
-   #:color_lab_to_rgb
-   #:color_rgb_to_lch
-   #:color_lch
-   #:color_lch_to_rgb
-   #:color_distance_ciede2000
-   #:color_rgb_to_yuv
-   #:color_yuv
-   #:color_yuv_to_rgb
-   #:get_allegro_color_version
+   #:color-cymk
+   #:color-cmyk-to-rgb
+   #:color-hsl
+   #:color-hsl-to-rgb
+   #:color-hsv
+   #:color-hsv-to-rgb
+   #:color-html
+   #:color-html-to-rgb
+   #:color-rgb-to-html
+   #:color-name
+   #:color-name-to-rgb
+   #:color-rgb-to-cmyk
+   #:color-rgb-to-hsl
+   #:color-rgb-to-hsv
+   #:color-rgb-to-name
+   #:color-rgb-to-yuv
+   #:color-yuv
+   #:color-yuv-to-rgb
+   #:get-allegro-color-version
    #:is-color-valid
    #:color-rgb-to-oklab
    #:color-oklab


### PR DESCRIPTION
Hey! The other day I needed conversion from some weird color space to RGB, but found out that the functions were imported out of cl-liballegro under wrong names (with underscores) and the actual function I needed had a typo in its name. I fixed those, but then ended up using regular `al:map-rgba`. Nevertheless, here are the fixes.