### PR TITLE
Tweaks to native textlog

### DIFF
--- a/src/constants/addons/native-dialogs.lisp
+++ b/src/constants/addons/native-dialogs.lisp
@@ -14,3 +14,7 @@
   (:ok-cancel 4)
   (:yes-no 8)
   (:question 16))
+
+(defbitfield textlog-flags
+  (:no-close 1)
+  (:monospace 2))

--- a/src/ffi-functions/addons/native-dialogs.lisp
+++ b/src/ffi-functions/addons/native-dialogs.lisp
@@ -21,7 +21,7 @@
 (defcfun ("al_close_native_text_log" close-native-text-log) :void
   (textlog :pointer))
 (defcfun ("al_append_native_text_log" append-native-text-log) :void
-  (textlog :pointer) (format :string))
+  (textlog :pointer) (format :string) &rest)
 (defcfun ("al_get_native_text_log_event_source" get-native-text-log-event-source)
     :pointer
   (textlog :pointer))


### PR DESCRIPTION
Hey! This PR does some small tweaks to [native text log](https://liballeg.org/a5docs/trunk/native_dialog.html#al_open_native_text_log) functionality:
* `al_append_native_text_log` is in fact variadic, just like `printf`;
* there were `ALLEGRO_TEXTLOG_*` constants missing.