### PR TITLE
Make use of CFFI:WITH-FOREIGH-SLOTS to simplify accessing Allegro structs

### DIFF
--- a/src/interface/interface.lisp
+++ b/src/interface/interface.lisp
@@ -19,11 +19,6 @@
    (accumulator :accessor accumulator :initform 0.0)
    (logic-fps :accessor logic-fps :initarg :logic-fps :initform 30)))
 
-(defmacro with-event (event &body body)
-  `(let ((,event (cffi:foreign-alloc '(:union al:event))))
-     ,@body
-     (cffi:foreign-free event)))
-
 ;;; Initializations
 (defgeneric initialize-event-queue (system)
   (:method (system)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -189,16 +189,81 @@
    #:event-display-orientation
 
    #:any-event
+   #:type
+   #:source
+   #:timestamp
+
    #:display-event
+   #:x
+   #:y
+   #:width
+   #:height
+   #:orientation
+
    #:joystick-event
+   #:id
+   #:stick
+   #:axis
+   #:pos
+   #:button
+
    #:keyboard-event
+   #:display
+   #:keycode
+   #:unichar
+   #:modifiers
+   #:repeat
+
    #:mouse-event
+   #:display
+   #:x
+   #:y
+   #:z
+   #:w
+   #:dx
+   #:dy
+   #:dz
+   #:dw
+   #:button
+   #:pressure
+
    #:timer-event
+   #:count
+   #:error
+
+   #:touch-event
+   #:display
+   #:id
+   #:x
+   #:y
+   #:dx
+   #:dy
+   #:primary
+
    #:user-event
+   #:data1
+   #:data2
+   #:data3
+   #:data4
+
+   #:audio-recorder-event
+   #:buffer
+   #:samples
+
    #:event
 
    #:event-source
    #:event-queue
+
+   #:with-event
+   #:with-display-event-slots
+   #:with-joystick-event-slots
+   #:with-keyboard-event-slots
+   #:with-mouse-event-slots
+   #:with-timer-event-slots
+   #:with-touch-event-slots
+   #:with-user-event-slots
+   #:with-audio-recorder-event-slots
 
    #:create-event-queue
    #:destroy-event-queue
@@ -635,7 +700,7 @@
    #:y
    #:z
    #:w
-   #:mouse-axis
+   #:more-axis
    #:buttons
    #:pressure
    #:display

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -189,73 +189,21 @@
    #:event-display-orientation
 
    #:any-event
-   #:type
-   #:source
-   #:timestamp
-
    #:display-event
-   #:x
-   #:y
-   #:width
-   #:height
-   #:orientation
-
    #:joystick-event
-   #:id
-   #:stick
-   #:axis
-   #:pos
-   #:button
-
    #:keyboard-event
-   #:display
-   #:keycode
-   #:unichar
-   #:modifiers
-   #:repeat
-
    #:mouse-event
-   #:display
-   #:x
-   #:y
-   #:z
-   #:w
-   #:dx
-   #:dy
-   #:dz
-   #:dw
-   #:button
-   #:pressure
-
    #:timer-event
-   #:count
-   #:error
-
    #:touch-event
-   #:display
-   #:id
-   #:x
-   #:y
-   #:dx
-   #:dy
-   #:primary
-
    #:user-event
-   #:data1
-   #:data2
-   #:data3
-   #:data4
-
    #:audio-recorder-event
-   #:buffer
-   #:samples
-
    #:event
 
    #:event-source
    #:event-queue
 
    #:with-event
+   #:with-event-slots
    #:with-display-event-slots
    #:with-joystick-event-slots
    #:with-keyboard-event-slots
@@ -707,6 +655,7 @@
 
    #:with-mouse-state
    #:with-current-mouse-state
+   #:with-mouse-state-slots
 ;;; Path
    #:create-path
    #:create-path-for-directory

--- a/src/types/events.lisp
+++ b/src/types/events.lisp
@@ -98,55 +98,55 @@
          `(,(intern (string slot) *package*) ,slot))
        all-slots)))
 
-(defmacro with-event-slots (event (&rest slots) &body body)
+(defmacro with-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(type source timestamp))
         ,event (:struct any-event))
      ,@body))
 
-(defmacro with-display-event-slots (event (&rest slots) &body body)
+(defmacro with-display-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(x y width height orientation))
         ,event (:struct display-event))
      ,@body))
 
-(defmacro with-joystick-event-slots (event (&rest slots) &body body)
+(defmacro with-joystick-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(id stick axis pos button))
         ,event (:struct joystick-event))
      ,@body))
 
-(defmacro with-keyboard-event-slots (event (&rest slots) &body body)
+(defmacro with-keyboard-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(display keycode unichar modifiers repeat))
         ,event (:struct keyboard-event))
      ,@body))
 
-(defmacro with-mouse-event-slots (event (&rest slots) &body body)
+(defmacro with-mouse-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(x y z w dx dy dz dw button pressure))
         ,event (:struct mouse-event))
      ,@body))
 
-(defmacro with-timer-event-slots (event (&rest slots) &body body)
+(defmacro with-timer-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(count error))
         ,event (:struct timer-event))
      ,@body))
 
-(defmacro with-touch-event-slots (event (&rest slots) &body body)
+(defmacro with-touch-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(display id x y dx dy primary))
         ,event (:struct touch-event))
      ,@body))
 
-(defmacro with-user-event-slots (event (&rest slots) &body body)
+(defmacro with-user-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(data1 data2 data3 data4))
         ,event (:struct user-event))
      ,@body))
 
-(defmacro with-audio-recorder-event-slots (event (&rest slots) &body body)
+(defmacro with-audio-recorder-event-slots ((&rest slots) event &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec slots '(buffer samples))
         ,event (:struct audio-recorder-event))

--- a/src/types/events.lisp
+++ b/src/types/events.lisp
@@ -80,37 +80,74 @@
 
 (defmacro with-event (event &body body)
   `(with-foreign-object (,event '(:union event))
-     (with-foreign-slots ((type source timestamp) ,event (:struct any-event))
-       ,@body)))
-
-(defmacro with-display-event-slots (event &body body)
-  `(with-foreign-slots ((x y width height orientation) ,event (:struct display-event))
      ,@body))
 
-(defmacro with-joystick-event-slots (event &body body)
-  `(with-foreign-slots ((id stick axis pos button) ,event (:struct joystick-event))
+(defun %foreign-slot-spec (requested-slots all-slots)
+  (if requested-slots
+      (loop :for slot :in requested-slots
+            :collecting
+               (etypecase slot
+                 (symbol
+                  `(,slot ,(intern (string slot) :cl-liballegro)))
+                 (cons
+                  (destructuring-bind (variable-name slot-name) slot
+                    `(,variable-name
+                      ,(intern (string slot-name) :cl-liballegro))))))
+      (mapcar
+       (lambda (slot)
+         `(,(intern (string slot) *package*) ,slot))
+       all-slots)))
+
+(defmacro with-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(type source timestamp))
+        ,event (:struct any-event))
      ,@body))
 
-(defmacro with-keyboard-event-slots (event &body body)
-  `(with-foreign-slots ((display keycode unichar modifiers repeat) ,event (:struct keyboard-event))
+(defmacro with-display-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(x y width height orientation))
+        ,event (:struct display-event))
      ,@body))
 
-(defmacro with-mouse-event-slots (event &body body)
-  `(with-foreign-slots ((x y z w dx dy dz dw button pressure) ,event (:struct mouse-event))
+(defmacro with-joystick-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(id stick axis pos button))
+        ,event (:struct joystick-event))
      ,@body))
 
-(defmacro with-timer-event-slots (event &body body)
-  `(with-foreign-slots ((count error) ,event (:struct timer-event))
+(defmacro with-keyboard-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(display keycode unichar modifiers repeat))
+        ,event (:struct keyboard-event))
      ,@body))
 
-(defmacro with-touch-event-slots (event &body body)
-  `(with-foreign-slots ((display id x y dx dy primary) ,event (:struct touch-event))
+(defmacro with-mouse-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(x y z w dx dy dz dw button pressure))
+        ,event (:struct mouse-event))
      ,@body))
 
-(defmacro with-user-event-slots (event &body body)
-  `(with-foreign-slots ((data1 data2 data3 data4) ,event (:struct user-event))
+(defmacro with-timer-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(count error))
+        ,event (:struct timer-event))
      ,@body))
 
-(defmacro with-audio-recorder-event-slots (event &body body)
-  `(with-foreign-slots ((buffer samples) ,event (:struct audio-recorder-event))
+(defmacro with-touch-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(display id x y dx dy primary))
+        ,event (:struct touch-event))
+     ,@body))
+
+(defmacro with-user-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(data1 data2 data3 data4))
+        ,event (:struct user-event))
+     ,@body))
+
+(defmacro with-audio-recorder-event-slots (event (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(buffer samples))
+        ,event (:struct audio-recorder-event))
      ,@body))

--- a/src/types/events.lisp
+++ b/src/types/events.lisp
@@ -77,3 +77,40 @@
 
 (defcstruct (event-source :size 128))
 (defcstruct event-queue)
+
+(defmacro with-event (event &body body)
+  `(with-foreign-object (,event '(:union event))
+     (with-foreign-slots ((type source timestamp) ,event (:struct any-event))
+       ,@body)))
+
+(defmacro with-display-event-slots (event &body body)
+  `(with-foreign-slots ((x y width height orientation) ,event (:struct display-event))
+     ,@body))
+
+(defmacro with-joystick-event-slots (event &body body)
+  `(with-foreign-slots ((id stick axis pos button) ,event (:struct joystick-event))
+     ,@body))
+
+(defmacro with-keyboard-event-slots (event &body body)
+  `(with-foreign-slots ((display keycode unichar modifiers repeat) ,event (:struct keyboard-event))
+     ,@body))
+
+(defmacro with-mouse-event-slots (event &body body)
+  `(with-foreign-slots ((x y z w dx dy dz dw button pressure) ,event (:struct mouse-event))
+     ,@body))
+
+(defmacro with-timer-event-slots (event &body body)
+  `(with-foreign-slots ((count error) ,event (:struct timer-event))
+     ,@body))
+
+(defmacro with-touch-event-slots (event &body body)
+  `(with-foreign-slots ((display id x y dx dy primary) ,event (:struct touch-event))
+     ,@body))
+
+(defmacro with-user-event-slots (event &body body)
+  `(with-foreign-slots ((data1 data2 data3 data4) ,event (:struct user-event))
+     ,@body))
+
+(defmacro with-audio-recorder-event-slots (event &body body)
+  `(with-foreign-slots ((buffer samples) ,event (:struct audio-recorder-event))
+     ,@body))

--- a/src/types/mouse.lisp
+++ b/src/types/mouse.lisp
@@ -19,7 +19,7 @@
      (al:get-mouse-state ,state)
      ,@body))
 
-(defmacro with-mouse-state-slots (state (&rest slots) &body body)
+(defmacro with-mouse-state-slots ((&rest slots) state &body body)
   `(with-foreign-slots
        (,(%foreign-slot-spec
           slots '(x y z w more-axis buttons pressure display))

--- a/src/types/mouse.lisp
+++ b/src/types/mouse.lisp
@@ -12,11 +12,16 @@
 
 (defmacro with-mouse-state (state &body body)
   `(with-foreign-object (,state '(:struct mouse-state))
-     (with-foreign-slots ((x y z w more-axis buttons pressure display)
-                          ,state (:struct mouse-state))
-       ,@body)))
+     ,@body))
 
 (defmacro with-current-mouse-state (state &body body)
   `(with-mouse-state ,state
      (al:get-mouse-state ,state)
+     ,@body))
+
+(defmacro with-mouse-state-slots (state (&rest slots) &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec
+          slots '(x y z w more-axis buttons pressure display))
+        ,state (:struct mouse-state))
      ,@body))

--- a/src/types/mouse.lisp
+++ b/src/types/mouse.lisp
@@ -12,7 +12,9 @@
 
 (defmacro with-mouse-state (state &body body)
   `(with-foreign-object (,state '(:struct mouse-state))
-     ,@body))
+     (with-foreign-slots ((x y z w more-axis buttons pressure display)
+                          ,state (:struct mouse-state))
+       ,@body)))
 
 (defmacro with-current-mouse-state (state &body body)
   `(with-mouse-state ,state


### PR DESCRIPTION
Here are the changes I propose as a followup to #21.

First of all, the `ALLEGRO_MOUSE_STATE` struct: I've added the call to [`cffi:with-foreign-slots`](https://cffi.common-lisp.dev/manual/cffi-manual.html#with_002dforeign_002dslots) macro inside of pre-existing `WITH-MOUSE-STATE` macro, so inside of it one can simply reference e.g. `al:x` or `al:y` instead of hideous `(cffi:foreign-slot-value mouse-state '(:struct al:mouse-state) 'al::x)`. I also exported all of symbols corresponding to that structure slots.

Second, the trickiest part: event struct, which is really a union of different structs. I took the liberty to rewrite pre-existing `WITH-EVENT` macro using [`cffi:with-foreign-object`](https://cffi.common-lisp.dev/manual/cffi-manual.html#with_002dforeign_002dobject) and also added call to [`cffi:with-foreign-slots`](https://cffi.common-lisp.dev/manual/cffi-manual.html#with_002dforeign_002dslots) to it to be able to reference the basic slots present in all events, i.e. `type`, `source` and `timestamp`. Next, I've added a bunch of macros based on [`cffi:with-foreign-slots`](https://cffi.common-lisp.dev/manual/cffi-manual.html#with_002dforeign_002dslots) to access slots of specific event types (that access could be done in user code after e.g. checking for the right `type` slot value). All of those macros are named like `with-...-event-slots` to emphasize that they don't allocate the event struct, but rather give simplified access to its slots.

That's not a huge change, but, on the contrary, just small QoL improvement so one doesn't have to invent something [like that](https://github.com/lockie/lispy-rogue/blob/main/src/common.lisp#L208-L214) 😅 @resttime let me know what you think.