### PR TITLE
Improvements to joystick state API

### DIFF
--- a/examples/009-joystick.lisp
+++ b/examples/009-joystick.lisp
@@ -37,8 +37,10 @@
           ;; :joystick-button-up, but its also possible to actively poll
           ;; current joystick state:
           (al:with-current-joystick-state joystick-state joystick
-            (al:with-joystick-axis (left-stick-horizontal :stick 0 :index 0)
-                                   joystick-state
+            (let ((left-stick-horizontal (al:get-joystick-state-axis
+                                          joystick-state
+                                          :stick 0
+                                          :index 0)))
               ;; stick 0 axis 0 corresponds to horizontal axis of left stick
               ;; in Xbox controller, but your mileage may vary
               (unless (zerop left-stick-horizontal)
@@ -47,11 +49,12 @@
                               text
                               left-stick-horizontal))))
             ;; you can also get multiple axes in one go:
-            (al:with-joystick-axes ((right-stick-horizontal :stick 1 :index 1)
-                                    (right-stick-vertical :stick 2 :index 0))
-                                   ;; again, indices are for Xbox controller,
-                                   ;; your mileage may vary
-                                   joystick-state
+            (al:with-joystick-state-axes
+                ((right-stick-horizontal :stick 1 :index 1)
+                 (right-stick-vertical :stick 2 :index 0))
+              ;; again, indices are for Xbox controller,
+              ;; your mileage may vary
+              joystick-state
               (unless (zerop right-stick-horizontal)
                 (setf text
                       (format nil "~a right stick horizontal axis moved to ~a~%"
@@ -63,16 +66,18 @@
                               text
                               right-stick-vertical))))
             ;; button indices are for Xbox controller, your mileage may vary
-            (al:with-joystick-button (menu :index 7) joystick-state
+            (let ((menu (al:get-joystick-state-button
+                         joystick-state
+                         :index 7)))
               (unless (zerop menu)
                 (setf text (format nil "~a menu button pressed: ~a~%"
                                    text menu))))
             ;; you can also get multiple buttons in one go:
-            (al:with-joystick-buttons ((a :index 0)
-                                       (b :index 1)
-                                       (x :index 2)
-                                       (y :index 3))
-                                      joystick-state
+            (al:with-joystick-state-buttons ((a :index 0)
+                                             (b :index 1)
+                                             (x :index 2)
+                                             (y :index 3))
+              joystick-state
               (unless (zerop a)
                 (setf text (format nil "~a A button pressed: ~a~%" text a)))
               (unless (zerop b)

--- a/examples/009-joystick.lisp
+++ b/examples/009-joystick.lisp
@@ -1,0 +1,93 @@
+;; Joystick state API example
+(ql:quickload "cl-liballegro")                 ; Load the system
+
+(defun get-first-joystick ()
+  (let (joystick)
+    (cond ((zerop (al:get-num-joysticks))
+           (error "No joysticks found!"))
+          ((cffi:null-pointer-p (setf joystick (al:get-joystick 0)))
+           (error "Error getting joystick!")))
+    joystick))
+
+(defun main ()
+  (al:init)
+  (al:init-font-addon)
+  (al:install-joystick)
+  (let* ((joystick (get-first-joystick))
+         (queue (al:create-event-queue))
+         (event (cffi:foreign-alloc '(:union al:event)))
+         (window-width  800)
+         (window-height 600)
+         (display (al:create-display window-width window-height))
+         (font (al:create-builtin-font)))
+    (al:register-event-source queue (al:get-display-event-source display))
+    (al:register-event-source queue (al:get-joystick-event-source))
+    (loop :while (loop :named event-loop
+                       :while (al:get-next-event queue event)
+                       :for type := (cffi:foreign-slot-value event
+                                                             '(:union al:event)
+                                                             'al::type)
+                       :when (eq type :joystick-configuration)
+                       :do (al:reconfigure-joysticks)
+                           (setf joystick (get-first-joystick))
+                       :never (eq type :display-close))
+          :for text := ""
+          :do
+          ;; One can process events :joystick-axis, :joystick-button-down and
+          ;; :joystick-button-up, but its also possible to actively poll
+          ;; current joystick state:
+          (al:with-current-joystick-state joystick-state joystick
+            (al:with-joystick-axis (left-stick-horizontal :stick 0 :index 0)
+                                   joystick-state
+              ;; stick 0 axis 0 corresponds to horizontal axis of left stick
+              ;; in Xbox controller, but your mileage may vary
+              (unless (zerop left-stick-horizontal)
+                (setf text
+                      (format nil "~a left stick horizontal axis moved to ~a~%"
+                              text
+                              left-stick-horizontal))))
+            ;; you can also get multiple axes in one go:
+            (al:with-joystick-axes ((right-stick-horizontal :stick 1 :index 1)
+                                    (right-stick-vertical :stick 2 :index 0))
+                                   ;; again, indices are for Xbox controller,
+                                   ;; your mileage may vary
+                                   joystick-state
+              (unless (zerop right-stick-horizontal)
+                (setf text
+                      (format nil "~a right stick horizontal axis moved to ~a~%"
+                              text
+                              right-stick-horizontal)))
+              (unless (zerop right-stick-vertical)
+                (setf text
+                      (format nil "~a right stick vertical axis moved to ~a~%"
+                              text
+                              right-stick-vertical))))
+            ;; button indices are for Xbox controller, your mileage may vary
+            (al:with-joystick-button (menu :index 7) joystick-state
+              (unless (zerop menu)
+                (setf text (format nil "~a menu button pressed: ~a~%"
+                                   text menu))))
+            ;; you can also get multiple buttons in one go:
+            (al:with-joystick-buttons ((a :index 0)
+                                       (b :index 1)
+                                       (x :index 2)
+                                       (y :index 3))
+                                      joystick-state
+              (unless (zerop a)
+                (setf text (format nil "~a A button pressed: ~a~%" text a)))
+              (unless (zerop b)
+                (setf text (format nil "~a B button pressed: ~a~%" text b)))
+              (unless (zerop x)
+                (setf text (format nil "~a X button pressed: ~a~%" text x)))
+              (unless (zerop y)
+                (setf text (format nil "~a Y button pressed: ~a~%" text y)))))
+          (al:clear-to-color (al:map-rgb 0 0 0))
+          (al:draw-multiline-text font (al:map-rgb 255 255 255)
+                                  0 0 window-width 8
+                                  0 text)
+          (al:flip-display))
+    (al:destroy-font font)
+    (al:destroy-display display)
+    (al:destroy-event-queue queue)
+    (al:release-joystick joystick)
+    (al:uninstall-system)))

--- a/src/constants/joystick.lisp
+++ b/src/constants/joystick.lisp
@@ -1,5 +1,9 @@
 (in-package :cl-liballegro)
 
+(defconstant +max-joystick-axes+ 3)
+(defconstant +max-joystick-sticks+ 16)
+(defconstant +max-joystick-buttons+ 32)
+
 (defcenum joyflags
   (:digital #x01)
   (:analogue #x02))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -478,6 +478,17 @@
    #:get-joystick-num-axes
    #:get-joystick-num-buttons
    #:get-joystick-state
+   #:+max-joystick-axes+
+   #:+max-joystick-sticks+
+   #:+max-joystick-buttons+
+   #:joystick-state
+   #:with-joystick-state
+   #:with-current-joystick-state
+   #:with-joystick-state-slots
+   #:with-joystick-axis
+   #:with-joystick-axes
+   #:with-joystick-button
+   #:with-joystick-buttons
    #:get-joystick-event-source
 
 ;;; Keyboard

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -485,10 +485,10 @@
    #:with-joystick-state
    #:with-current-joystick-state
    #:with-joystick-state-slots
-   #:with-joystick-axis
-   #:with-joystick-axes
-   #:with-joystick-button
-   #:with-joystick-buttons
+   #:get-joystick-state-axis
+   #:with-joystick-state-axes
+   #:get-joystick-state-button
+   #:with-joystick-state-buttons
    #:get-joystick-event-source
 
 ;;; Keyboard

--- a/src/types/joystick.lisp
+++ b/src/types/joystick.lisp
@@ -20,53 +20,40 @@
         ,state (:struct al:joystick-state))
      ,@body))
 
-(defmacro with-joystick-axis ((value &key stick index) state &body body)
-  `(let ((,value
-           (mem-aref
-            (foreign-slot-value ,state '(:struct al:joystick-state)
-                                'al::stick-axis)
-            :float (+ (* ,stick al:+max-joystick-axes+) ,index))))
-     (declare (type (single-float -1.0 1.0) ,value))
-     ,@body))
+(declaim (inline get-joystick-state-axis))
+(defun get-joystick-state-axis (state &key stick index)
+  (the (single-float -1.0 1.0)
+       (mem-aref (foreign-slot-value state '(:struct joystick-state)
+                                     'stick-axis)
+                 :float (+ (* stick al:+max-joystick-axes+) index))))
 
-(defmacro with-joystick-axes ((&rest axes) state &body body)
+(defmacro with-joystick-state-axes ((&rest axes) state &body body)
   (let* ((axes-names (mapcar #'first axes))
          (axes-params (mapcar #'rest axes))
          (axes-sticks (mapcar (lambda (a) (getf a :stick)) axes-params))
-         (axes-index (mapcar (lambda (a) (getf a :index)) axes-params))
-         (axis-var (gensym "STICK-AXIS")))
-    `(let* ((,axis-var
-              (foreign-slot-value ,state '(:struct al:joystick-state)
-                                  'al::stick-axis))
-            ,@(mapcar
-                (lambda (name stick index)
-                  `(,name
-                    (mem-aref
-                     ,axis-var
-                     :float (+ (* ,stick al:+max-joystick-axes+) ,index))))
-                axes-names axes-sticks axes-index))
+         (axes-index (mapcar (lambda (a) (getf a :index)) axes-params)))
+    `(let (,@(mapcar
+               (lambda (name stick index)
+                 `(,name
+                   (get-joystick-state-axis ,state :stick ,stick :index ,index)))
+               axes-names axes-sticks axes-index))
        (declare (type (single-float -1.0 1.0) ,@axes-names))
        ,@body)))
 
-(defmacro with-joystick-button ((value &key index) state &body body)
-  `(let ((,value
-           (mem-aref
-            (foreign-slot-value ,state '(:struct al:joystick-state)
-                                'al::button)
-            :int ,index)))
-     (declare (type (integer 0 32767) ,value))
-     ,@body))
+(declaim (inline get-joystick-state-button))
+(defun get-joystick-state-button (state &key index)
+  (the (integer 0 32767)
+       (mem-aref (foreign-slot-value state '(:struct joystick-state)
+                                     'button)
+                 :int index)))
 
-(defmacro with-joystick-buttons ((&rest buttons) state &body body)
+(defmacro with-joystick-state-buttons ((&rest buttons) state &body body)
   (let* ((buttons-names (mapcar #'first buttons))
          (buttons-params (mapcar #'rest buttons))
-         (buttons-indices (mapcar (lambda (b) (getf b :index)) buttons-params))
-         (buttons-var (gensym "BUTTONS")))
-    `(let* ((,buttons-var
-              (foreign-slot-value ,state '(:struct al:joystick-state)
-                                  'al::button))
-            ,@(mapcar (lambda (name index)
-                        `(,name (mem-aref ,buttons-var :int ,index)))
+         (buttons-indices (mapcar (lambda (b) (getf b :index)) buttons-params)))
+    `(let* (,@(mapcar (lambda (name index)
+                        `(,name
+                          (get-joystick-state-button ,state :index ,index)))
                       buttons-names buttons-indices))
        (declare (type (integer 0 32767) ,@buttons-names))
        ,@body)))

--- a/src/types/joystick.lisp
+++ b/src/types/joystick.lisp
@@ -1,4 +1,72 @@
 (in-package #:cl-liballegro)
 
 (defcstruct joystick)
-(defcstruct joystick-state)
+(defcstruct joystick-state
+  (stick-axis :float :count #.(* +max-joystick-sticks+ +max-joystick-axes+))
+  (button :int :count #.+max-joystick-buttons+))
+
+(defmacro with-joystick-state (state &body body)
+  `(with-foreign-object (,state '(:struct al:joystick-state))
+     ,@body))
+
+(defmacro with-current-joystick-state (state joystick &body body)
+  `(with-joystick-state ,state
+     (al:get-joystick-state ,joystick ,state)
+     ,@body))
+
+(defmacro with-joystick-state-slots ((&rest slots) state &body body)
+  `(with-foreign-slots
+       (,(%foreign-slot-spec slots '(stick-axis button))
+        ,state (:struct al:joystick-state))
+     ,@body))
+
+(defmacro with-joystick-axis ((value &key stick index) state &body body)
+  `(let ((,value
+           (mem-aref
+            (foreign-slot-value ,state '(:struct al:joystick-state)
+                                'al::stick-axis)
+            :float (+ (* ,stick al:+max-joystick-axes+) ,index))))
+     (declare (type (single-float -1.0 1.0) ,value))
+     ,@body))
+
+(defmacro with-joystick-axes ((&rest axes) state &body body)
+  (let* ((axes-names (mapcar #'first axes))
+         (axes-params (mapcar #'rest axes))
+         (axes-sticks (mapcar (lambda (a) (getf a :stick)) axes-params))
+         (axes-index (mapcar (lambda (a) (getf a :index)) axes-params))
+         (axis-var (gensym "STICK-AXIS")))
+    `(let* ((,axis-var
+              (foreign-slot-value ,state '(:struct al:joystick-state)
+                                  'al::stick-axis))
+            ,@(mapcar
+                (lambda (name stick index)
+                  `(,name
+                    (mem-aref
+                     ,axis-var
+                     :float (+ (* ,stick al:+max-joystick-axes+) ,index))))
+                axes-names axes-sticks axes-index))
+       (declare (type (single-float -1.0 1.0) ,@axes-names))
+       ,@body)))
+
+(defmacro with-joystick-button ((value &key index) state &body body)
+  `(let ((,value
+           (mem-aref
+            (foreign-slot-value ,state '(:struct al:joystick-state)
+                                'al::button)
+            :int ,index)))
+     (declare (type (integer 0 32767) ,value))
+     ,@body))
+
+(defmacro with-joystick-buttons ((&rest buttons) state &body body)
+  (let* ((buttons-names (mapcar #'first buttons))
+         (buttons-params (mapcar #'rest buttons))
+         (buttons-indices (mapcar (lambda (b) (getf b :index)) buttons-params))
+         (buttons-var (gensym "BUTTONS")))
+    `(let* ((,buttons-var
+              (foreign-slot-value ,state '(:struct al:joystick-state)
+                                  'al::button))
+            ,@(mapcar (lambda (name index)
+                        `(,name (mem-aref ,buttons-var :int ,index)))
+                      buttons-names buttons-indices))
+       (declare (type (integer 0 32767) ,@buttons-names))
+       ,@body)))


### PR DESCRIPTION
Hey @resttime! Hope this message finds you well 😊 
Do you mind having a look at the API I've implemented for [joystick state](https://liballeg.org/a5docs/trunk/joystick.html#allegro_joystick_state)? I've battle-tested it in my [current project](https://awkravchuk.itch.io/imcaving) and even wrote a working example (with Xbox controller at least), but this is quite substantial change and you may have some comments on the API design.

Thing is, unlike keyboard state and mouse state, fields in `ALLEGRO_JOYSTICK_STATE` are public and should be accessed directly, which may prove cumbersome in CL. I wrote a few macros to nicely access all the info that structure contains.